### PR TITLE
Revert "Missing a 'b'"

### DIFF
--- a/Doc/README.md
+++ b/Doc/README.md
@@ -12,7 +12,7 @@ A server is running on bitcoinauthenticator.org which you can use with the Clien
 ### Running
 Start mongodb 
 ```
-sudo service mongodb start
+sudo service mongod start
 ```
 
 Start the subspace server


### PR DESCRIPTION
Reverts BitcoinAuthenticator/Subspace#6

It isn't supposed to have a b in there. 
